### PR TITLE
Add negative_prompt

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -43,7 +43,7 @@ class Predictor(BasePredictor):
         ),
         negative_prompt: str = Input(
             description="Negative Prompt",
-            default=None
+            default="monochrome, lowres, bad anatomy, worst quality, low quality"
         ),
         num_outputs: int = Input(
             description="Number of images to output.",

--- a/predict.py
+++ b/predict.py
@@ -41,6 +41,10 @@ class Predictor(BasePredictor):
             description="Prompt",
             default="photo of a beautiful girl wearing casual shirt in a garden"
         ),
+        negative_prompt: str = Input(
+            description="Negative Prompt",
+            default=None
+        ),
         num_outputs: int = Input(
             description="Number of images to output.",
             ge=1,
@@ -70,7 +74,8 @@ class Predictor(BasePredictor):
             num_samples=num_outputs,
             num_inference_steps=num_inference_steps,
             seed=seed,
-            prompt=prompt
+            prompt=prompt,
+            negative_prompt=negative_prompt
         )
 
         output_paths = []


### PR DESCRIPTION
Requested by @fofr
Not fantastic results. You can exactly cancel out positive prompts, so it is at least working.

Note that negative_prompt defaults to `negative_prompt = "monochrome, lowres, bad anatomy, worst quality, low quality"` in https://github.com/tencent-ailab/IP-Adapter/blob/e317f750e1829e846c944b9fdd7a2f2842c46501/ip_adapter/ip_adapter.py#L240C1-L240C1

ai_face2.png
<img src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/3869fbb3-f724-4ac1-9f53-40e8a03361fa" width="200px"/>

No prompts
`cog predict -i image=@ai_face2.png -i prompt="" -i negative_prompt="" -i seed=42`
<img src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/f731f039-16fe-4d67-bb3a-639990d307c6" width="200px"/>

Positive prompt
`cog predict -i image=@ai_face2.png -i prompt="in a garden" -i negative_prompt="" -i seed=42`
<img src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/205211aa-aec7-4031-a185-be749024c8f7" width="200px"/>

Cancelling out positive prompt
`cog predict -i image=@ai_face2.png -i prompt="in a garden" -i negative_prompt="in a garden" -i seed=42`
<img src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/e64c062b-887b-4534-8267-f8179b9932e6" width="200px"/>

Just a negative prompt on its own (it can be hard to get this to affect the input image)
`cog predict -i image=@ai_face2.png -i prompt="" -i negative_prompt="white shirt" -i seed=42`
<img src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/eb41a79f-d270-4e50-8d71-3e71122dd9e2" width="200px"/>


