### PR TITLE
Scale

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -45,6 +45,12 @@ class Predictor(BasePredictor):
             description="Negative Prompt",
             default=""
         ),
+        scale: float = Input(
+            description="Scale (influence of input image on generation)",
+            ge=0.0,
+            le=1.0,
+            default=0.6
+        ),
         num_outputs: int = Input(
             description="Number of images to output.",
             ge=1,
@@ -75,7 +81,8 @@ class Predictor(BasePredictor):
             num_inference_steps=num_inference_steps,
             seed=seed,
             prompt=prompt,
-            negative_prompt=negative_prompt
+            negative_prompt=negative_prompt,
+            scale=scale
         )
 
         output_paths = []

--- a/predict.py
+++ b/predict.py
@@ -38,12 +38,12 @@ class Predictor(BasePredictor):
              default=None
         ),
         prompt: str = Input(
-            description="Prompt",
-            default="photo of a beautiful girl wearing casual shirt in a garden"
+            description="Prompt (leave blank for image variations)",
+            default=""
         ),
         negative_prompt: str = Input(
             description="Negative Prompt",
-            default="monochrome, lowres, bad anatomy, worst quality, low quality"
+            default=""
         ),
         num_outputs: int = Input(
             description="Number of images to output.",


### PR DESCRIPTION
`scale` param lets you set how much influence the input image has


`cog predict -i image=@ai_face2.png -i prompt="best quality, high quality, wearing sunglasses on the beach" -i scale=0.0 -i seed=42`
<img src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/2d97bbfd-3d46-4b2f-be52-b3cc9bda9679" width="200px">

`cog predict -i image=@ai_face2.png -i prompt="best quality, high quality, wearing sunglasses on the beach" -i scale=0.5 -i seed=42`
<img src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/57f6e975-9ed8-4954-8da6-7fe619ec11b0" width="200px">

`cog predict -i image=@ai_face2.png -i prompt="best quality, high quality, wearing sunglasses on the beach" -i scale=1.0 -i seed=42`
<img src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/b7d7ca80-7ba2-4323-ba90-01ede2608cf1" width="200px">

Removing default prompts allows leaving prompts blank to get image variations
`cog predict -i image=@ai_face2.png -i prompt="" -i scale=0.6 -i seed=42`
<img src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/3722bbfe-83fb-4248-a15b-ea44d3112f60" width="200px">
