### PR TITLE
Make image a required param

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -34,8 +34,7 @@ class Predictor(BasePredictor):
     def predict(
         self,
         image: Path = Input(
-             description="Input face image",
-             default=None
+             description="Input face image"
         ),
         prompt: str = Input(
             description="Prompt",


### PR DESCRIPTION
Currently, if you don't add an image, you get an error:
<img width="1137" alt="Screenshot 2023-11-10 at 19 28 25" src="https://github.com/lucataco/cog-ip_adapter-sdxl-face/assets/14337872/221fc57f-63aa-4761-a10f-0b1aee6ff640">

This makes `image` required
